### PR TITLE
Corrections to the landing page content

### DIFF
--- a/css/scrolling-nav.css
+++ b/css/scrolling-nav.css
@@ -390,6 +390,16 @@ padding of sections and children of those sections to manage the look and feel o
 
 .locations-tab h4 {
     color: #9e9e9e;
+    margin-bottom: 0;
+}
+
+.locations-tab ul li {
+    padding-bottom: 6px;
+}
+
+.locations-tab-contact-link {
+    font-size: 1.2rem;
+    margin-top: -2px;
 }
 
 .locations-desc {
@@ -422,7 +432,8 @@ padding of sections and children of those sections to manage the look and feel o
 }
 
 .pin-text {
-    font-size: 7px;
+    font-size: 0.7rem;
+    font-weight: normal;
 }
 
 @media(max-width:767px) {

--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
                             Region affiliated with the Meliá Hotels International brands.
                         </p>
                         <p>
-                            If you wish to apply for a position in our corporate offices, please click here.
+                            If you wish to apply for a position in our corporate offices, please <a href="https://corporateregionalamerica.talentnest.com" target="_blank" rel="noopener noreferrer">click here</a>.
                         </p>
                     </div>
                     <div class="brands-video">
@@ -247,9 +247,6 @@
                         </p>
                         <ul class="brands-link-list">
                             <li>
-                                <a href="https://meliabracovillage.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">Meliá Braco Village</a>
-                            </li>
-                            <li>
                                 <a href="https://clubmeliadominicana.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">Club Meliá Tropicana</a>
                             </li>
                         </ul>
@@ -278,9 +275,6 @@
                                 <a href="https://mecabo.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">ME Cabo</a>
                             </li>
                             <li>
-                                <a href="https://meliahotels.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">ME Cancun</a>
-                            </li>
-                            <li>
                                 <a href="https://memiami.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">ME Miami</a>
                             </li>
                         </ul>
@@ -307,7 +301,7 @@
                         </p>
                         <ul class="brands-link-list">
                             <li>
-                                <a href="https://innsideny.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">Innside New York</a>
+                                <a href="https://innsideny.talentnest.com/en/jobs" target="_blank" rel="noopener noreferrer">Innside New York Nomad</a>
                             </li>
                         </ul>
                     </div>
@@ -394,6 +388,7 @@
                         <path id="BZ" d="M99.94 108.67c0-.66.33-.64.83-.22.4-.7.65-1.82 1.53-1.8.36.37-.05.16.54.43.05.8-.36 1.33-.5 2.07-.1.46.2 1.4.1 1.93-.24 1.08-1.38 3.58-2.74 3.18.13-1.87.22-3.7.24-5.6v.02z"/>
                         <path id="CL" d="M157.44 332.44v8.6c0 1.15-.46 1.97.78 1.97 1.32.1 2.6.1 3.9.2-1.1 2.4-2.55 3.9-5.28 3.2-1.32-.3-1.93-1.1-3.12-1.7-.86-.4-2.25-.2-3-.7-2.1-1.6-4.1-3.2-6.08-5-1.63-1.4-2.8-3.7-4.1-5.4 1.88.8 3.08 1.6 4.7 2.9 1.62 1.3 3.27 2 5.17 2.9 1 .4 2.3-4.8 2.5-5.2.2-.6 1.8-1.4 2.3-1.7.6-.5 1.6.1 2.3.3zm1.16-112c.2.72.52 3.8 1.1 4.15.43.2 1.6-.7 2.02-.5.67.4.1 1.6-.06 2-.62 2-1 2-2.95 3-1.3.6-.6 3.1-.5 4.4 0 .7.1.9-.2 1.5-.5.9.7.9.6 1.7 0 .5-2.4 2.7-2.9 3.4-.8 1.3-1.3 2.5-1.8 4-.4 1.2.6 2.6 0 3.7-.5 1-1.7 2.4-1.4 3.6.4 1.7.6 3.6 1.2 5.2.3.8.8.3.8 1.4 0 .7.2 1.6 0 2.3-.3 1.5-1.6 2.5-1.6 4.2.1 2.1-.3 2.3-1.8 3.9-.6.7-.4 2.9-.1 3.8.5 2 1.3 2.7-.4 4-1 .7-1 2.7-1.2 3.9-.4 2.5-.5 4.3-.2 6.9.1.1.2.8.1 1-.1.3-1.1.5-1.1.8l.6 4c.1.6 1.5 1.5 1.3 1.9-.8 1.4-1.1 1.3.3 2.2 1.2.7 0 1.8-.6 2.2-.6.3.2 1.9.1 2.5-.4 2.1-.6 4.3-1.5 6.3-.4.9-1.1 2-.9 3 .2 1.4.1 2-.4 3.4-.4 1.1-1.2 1.6-2.1 2.4-.7.6-.2 2-.2 2.8.1 1.1 0 1.8.6 2.8.7 1.1 1.1.7 2.4.5 0 2.1-.4 5.8 2.3 6.1 2.9.2 5.5.5 8.3 1.2-.6 0-2.1-.3-2.6.1-.8.7-1.7 1.4-2.6 2-1.2.8-1.1.9-1.2 2.3-.1 1 .2 2.7-.9 2.8-1.9.2-3.9-1.7-5.2-2.9-1.6-1.7-3.3-3-5.2-4.4-1.5-1.2-.6-4.1-.2-5.5.2-.7-1-2.4-1.3-3-.3-.7-.1-1.9-.2-2.7-.1-2.4-.3-4.4.4-6.7s1.9-3.4 3.5-5.2l-4.2-1.2c.9-1.2 2.5-2.6 2.7-4.1l.9-6.1 3.2 1.3 1.1-5.6c.4-2.4.7-2.3-1.4-3.4l-.9 4.7c-2.2-.7-1.7-.8-1.4-3l.6-4.2.8-5.5c.2-1.4 1.5-2.1 1.2-3.5-.4-1.6-.7-2.9-.8-4.5 0-.4-.3-2-.1-2.3.4-.6 1.1.3 1.3-.6 1-3.3 2-6.5 3.2-9.7 1-2.8 1.5-5.4 1.1-8.3-.3-1.8-.3-2.6.2-4.3.5-1.5.1-3.1-.1-4.7-.1-1 1.2-2.9 1.6-3.9.6-1.3.4-3.4.5-4.8.2-2.6.7-5.2 1.1-7.8.4-3.4.8-6.6.7-10-.1-1.5-.3-3-.5-4.5-.2-1.1-.3-1 .8-1.6.7-.4.9-1 1.2-1.8.5.8 1.3 1.6 1.4 2.5.1.4.1 1.4.4 1.7s1.3.8 1.4 1.2c.3.7-.9 2.1-.9 2.9.1 1 1.1 2.4 1.5 3.4z"/>
                         <path id="CR" d="M117.26 136.12c-.74-.3-1.4-.5-1.94-1.07-.32-.33.28-1.1-.5-1.77-.56-.48-1.34-.74-2.03-1-.6-.2-.4-1.1-1.2-1.43.3.58.1 1.14-.4 1.5-.5-.9-1.6-.73-1.9-1.63-.4-.93 1.1-1.86-.4-2.16.2-.2.9-.96 1.2-.85.6.3 1.4.9 2 .6 1.2-.7 2.1 1.9 3.1.2.8 1.7 1.8 2.7 3.1 3.9-1.3-.1-1.6 1.3-.5 1.8-.6.5-.4 1.3-.7 2z"/>
+                        <path id="CU" d="M119.2 92.66c1.76.15 3.85-.07 5.47.57 1.06.4 1.74.64 2.53 1.42.68.68 1.7.23 2.6.1 1.18-.15 3.04 1.95 3.9 2.62 1.08.83 1.43.88 2.54 1.2.83.26 2.1.38 1.47 1.46 1.7.1 2.4.27 3.8 1.1 1.4.78-1.2 1.24-1.8 1.3-2.5.37-5.2.03-7.8.2l1.9-1.65c-1.3-.87-2.6-.68-3.7-1.7-.4-.4-.3-1.56-.8-1.83-.4-.23-1.2.22-1.7.08-1.1-.35-2.6-1.3-3.7-1.45-1.4-.17-3.1-.05-4.2-1 .4-.22.7-.57 1.1-.76l-2.6-.14c-.7-.04-1.5 1.27-2.1 1.55-.2.1-.7.03-1 .04-.4 0-.2.6-.5.74-.8.4-1.7.4-2.6.1 1.4-.8 2-2 3.4-2.7 1.4-.6 3-.5 4.3-1.2z"/>
                         <path id="EC" d="M124.73 168.6c1.03-1.46 1.68-1.7.88-3.3-1 1.3-.9 1.4-2.3.37-.4-.28 0-1.76-.1-2.63-.2-1.4.7-1.15 1.2-2.54.3-1.04 1.4-1.9 1.2-2.97-.1-1 1.2-1 2-1.45 1.7-1 1.8-.62 3.5.35.4.2.6.43 1 .4.7-.07.5.86 1 1.16.4.2 1.5.2 1.9.3.5.1.9-.5 1.3-.4.3 0 2.4 1.3 2.6 1.6.8 1 .2 2.5-.2 3.4-.9 1.9-3 3.3-5 3.9-1.4.4-1.7.5-2.5 1.7-.7.9-.8 2.2-1.4 3.1-.9 1.2-1.5 1.2-2.3.2-.7-.8-1.7-.9-2.7-.6-.5-1.4 1.2-1.4.4-2.9z"/>
                         <path id="FK" d="M178.3 328.85c.76-.62 2.8-2.95 3.72-2.52.34.16 1.86 1.1 2.1.85.46-.48 1.3-1.96 1.88-1.44.9.82 3.22 2.58.8 3.45l-3.14 1.1c-.67.2-1.2-1-1.6-1.5-.78.7-1.58 1.3-2.37 2l-1.4-2.1z"/>
                         <path id="GF" d="M202.52 152.13c-.7.7-2.03 2.03-2.7.68-.27-.5-.82-.2-1.15.1-.64.6-.92.2-1.66-.2.6-.9.7-1.4 1-2.4.4-1.4.4-1.3-.5-2.7-.3-.5-.4-1.8 0-2.4l1-1.6c.4-.6.6-.1 1.2 0 1.5.2 4.6 1.8 5.1 3.2.7 1.7-1.4 3.9-2.1 5.6z"/>
@@ -412,84 +407,77 @@
                         <g id="pin-group-peru" class="pin-group pin-group-peru">
                             <path id="PE" class="country" stroke="#FFF" stroke-width=".5" d="M154.76 208.85c-.62 1.26-.8 1.54-2.04 2.18-.5.26-2.35-1.24-2.86-1.55-.58-.34-.26-1.2-1.13-1.66l-4-2.1c-1.92-1.02-3.73-2.28-5.58-3.45-.9-.57-4.2-3.1-3.43-4.5.75-1.36-1.72-3.78-2.46-5.18-1.06-2-2.13-4-3.1-6.1l-1.78-3.8c-.36-.8-1.13-1.3-1.48-2.1-.96-2.3-2.73-3.3-4.83-4.5.37-.5 1.05-1 .74-1.6-.2-.6-1.1-1.7-1.1-2.4 0-1.7 2.1-2.9 3.1-3.8.9 1.4-.9 1.4-.4 2.8.9-.3 1.4-.2 2.2 0 .9.2.9 1.8 1.8 1.1 1.6-1.1 1.8-2.8 2.9-4.4 1-1.4 3-.9 4.2-2.1 1.5-1.5 2.7-2.5 3.6-4.4.3-.5-.6-1.8-.3-2.2.6-.8 1.8.5 2.3.8.6.4.8 1.1 1.3 1.6 1 .8 1.4.7 2 1.9 1.2 2.1 2.3 2.5 4.5 1.4.2-.1 2.1.3 2.7.2.7-.1 1.8 1 2.3 1.3l-1.8 2.8c1-.2 1.6.9 2.2 1.5-1.7-.1-3.7-.1-5.3.9-.8.4-2.6 1.1-3.1 1.8 0 0-.9 2.5-.9 2.4.3 1.5.2 1.4-1.3 2.1.2-.1-.6 2.2-.8 1.8.4.9.8 2 1.4 2.8 1.1 1.2 1.4 1.1.7 2.6.5 0 1.4-.1 1.9.1.8.4.6 1.5 1.6 1.5 2.1 0 2.6-.4 4.3-1.6l-.1 4c0 1.1 2.2.3 2.7.2.4-.2 1.6 2.7 1.9 3.2.9 1.6.2 1.2.1 2.8 0 1.2-.1 2.5-.1 3.8 0 .4-.7 1-1 1.4-.3.4.6.9.3 1.3-.8 1.2 0 1.9.6 3.2.3.5-1.4 2.7-1.7 3.2z"/>
                             <path class="pin peru" d="M136.78 180.9c-.12.87.5 1.66 1.35 1.77v3l.22.75.2-.75v-3c.8-.1 1.38-.77 1.38-1.57 0-.87-.7-1.57-1.58-1.57-.8 0-1.47.58-1.57 1.37z"/>
-                            <text class="pin-text peru" transform="translate(133.41 178.52)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text peru" transform="translate(128.41 178.52)">
                                 Peru
                             </text>
                         </g>
                         <g id="pin-group-panama" class="pin-group pin-group-panama">
                             <path id="PA" class="country" stroke="#FFF" stroke-width=".5" d="M131.5 138.93c-.9-.63-2.22-2.28-.83-3.08-1.1-.07-2.86-3.48-4.14-1.23-.4.7-1.83.9-2.03 1.3-.48.9.45 1.4 1.06 2.1-1.86.6-2.23 1.73-2.96-.76-.8 1.5-1.65-.8-2.42-.9-.78-.14-2.6-1.14-2.6.18-.5-.52-.1-2.04.37-2.4-1.4-.7-.25-2.56 1-1.3.58.6.2 1.08 1 1.17.82.1.7-.2 1.4.4.8.8 2.53-.6 3.36-.9 1.6-.5 1.9-1.2 3.7-1l-.1.3c2.2.2 3.1 1 4.8 2.2-.7.9.7 1.6.2 2.3-.4.7-.3.7-1 .5-.4-.1-.5.9-.6 1.3z"/>
                             <path class="pin panama" d="M121.68 130.42c-.1.86.5 1.66 1.36 1.77v2.9l.2.7.22-.8v-3c.8-.1 1.38-.8 1.38-1.6 0-.9-.7-1.6-1.6-1.6-.78 0-1.45.6-1.56 1.4z"/>
-                            <text class="pin-text panama" transform="translate(113.68 127.655)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text panama" transform="translate(113.68 127.655)">
                                 Panama
                             </text>
                         </g>
                         <g id="pin-group-venezuela" class="pin-group pin-group-venezuela">
                             <path id="VE" class="country" stroke="#FFF" stroke-width=".5" d="M149.88 126.06c.03 1-.9.84-1.73 1 .54.76.93 1.1.9 2.04-.03 1.06-1.16 1.5-1.25 2.38-.02.26.84 2.14 1.06 2.24 1.2.57 1.47-1 1.68-1.7.34-1.1-2.22-3.2-.1-3.9.4-.14 2.6-.56 2.74-.92.46-1.1-1-1.28.6-2.24.38.77.6 2 1.5 2.02 1.64.04 1.95.45 3.2 1.53.24.3 0 .9.2 1.1.34.3 1.6 0 2.02 0 1.13 0 2.26-.1 3.4-.3.64 0 1.46 1.2 2.26 1.4.88.2 3.1.5 3.17-1 .03-.8 5.94-.5 6.85-.5l-2.38.8c.66.9.73 1.3 1.84 1.4 1.37.1 1.88.5 3.06 1.3.75.5.68 1.6.85 2.4-.04-.2 2.24.5 2.58.7-1.67 1.3-3.23 1.9-1.5 3.8-.62.6-1.44.7-2.25.9.4-.1-.84 2.3-.88 2.1.2 1 4.06 3 1.14 4-1.65.5-4.33.8-5.65 1.9-1 .8-3.7-1.4-5.1-.6 1.4.8 1.2.9 1.1 2.5-.1 1.3.2 1.9 1.3 2 1.3.1 2.3.5.6 1.1-1.4.6-1 1.5-2.3 2-1.1.4-2.1.4-2.7 1.4-.7 1-2.5.3-3.1-.3-1.6-1.5-1.1-4-3.4-5.1.3-.3 1.3-1 1.4-1.4.1-.7-.6-.9-.9-1.4-.5-1-.9-3-.3-4 .4-.7 1.9-3.1-.1-2.7-1.5.3-3 0-4.4.4-.7.2-1.8-2.3-2.8-2.5-1.4-.3-3.5.5-4.7.1.2.1-1.5-1.5-1.4-1.2-.3-.8.2-1.4.1-2.2-.2-.7-.7-.8-.8-1.4-.4-1.3-.5-1.1-1.8-1.3.7-1.5.8-3.3 1.8-4.6 1.1-1.4 2-2.4 3.7-2.8z"/>
                             <path class="pin venezuela" d="M166 136.86c-.12.86.5 1.66 1.35 1.77v3l.2.75.22-.76v-3c.8-.1 1.38-.76 1.38-1.56 0-.87-.7-1.58-1.6-1.57-.78-.1-1.45.5-1.56 1.3z"/>
-                            <text class="pin-text venezuela" transform="translate(152.36 134.095)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text venezuela" transform="translate(152.36 134.095)">
                                 Venezuela
                             </text>
                         </g>
                         <g id="pin-group-colombia" class="pin-group pin-group-colombia">
                             <path id="CO" class="country" stroke="#FFF" stroke-width=".5" d="M138.55 159.52c-.64-.35-1.9-1.47-2.58-1.58-.3-.04-.6.48-.93.42-.7-.1-1.4-.23-2.12-.34-.32-.06-.55-.77-.7-1.04-.16-.27-.66-.15-.98-.34-.97-.54-2.62-1-2.84-2.25 1.87.1.22-2.5 2.28-2.8 1.3-.2 2.18-2.3 2.95-3.3-1.6-.7-.58-1.1-.5-2.3.03-.8-1-2.2-.5-2.8 1.68-2-2.2-4.1-.76-5.8.2-.2.76.4 1.05 0 .47-.8.3-.9-.03-1.7-.7-1.6 1.1-.6 1.8-1.2.9-.9 1.5-1.6 2.7-1.9.2-.1.6-2.9.7-3.3.4-1.9 4.4-2 5.6-1.9 1.8.2 3.3-3.1 4.8-3.4 1.2-.3 2.1 1 1.2 1.9-.4.4-1.4.1-1.8.5-.4.3-.4 1-.7 1.4-.6.6-1.8 1-2 2-.3 1.3-.6 2.3-1.1 3.5.9.1 1.3-.1 1.6.8.1.6.7.9.8 1.4.1.6-.3 1.6-.2 2 .2.7.8.9 1.3 1.6.4.6 3-.3 3.9-.1.6.1 1.2.1 1.7.6.4.4 1.1 1.9 1.7 2.1.3.1 1.2-.3 1.6-.3.7.1 1.3.1 2 0 2-.4 2.2.7 1.2 2.2-.9 1.3-.4 2.8 0 4.2.1.5.8.7.9 1.3.1.6-.9 1.2-1.4 1.7 1.1.5 3.7 4 2.1 4.7-.4-1-.6-1.8-1.4-2.6-1.4 1.7-4.3 1-6.4.9 0 .4-.2 1.7.2 1.8 1 .2 1.9 0 1.4 1.3-1.8-1.2-2.1.8-2.1 2.1 0 .8 1.7 1.5 1.6 2.9-.1 2.9-.8 5.8-1.3 8.7-.6-.7-1.2-1.8-2.2-1.6l1.8-2.9-2-1.2c-.6-.4-1.4.3-2.1 0-1-.5-3.8 1.2-4.5-.1l-1.4-2.5c-.4-.6-1.2-.6-1.6-1.2-.7-1-2.1-3.1-3.4-2.3z"/>
                             <path class="pin colombia" d="M142.78 146.14c-.1.87.5 1.66 1.36 1.77v3l.2.8.22-.7v-3c.8-.1 1.38-.7 1.38-1.5s-.72-1.6-1.6-1.5c-.78 0-1.46.6-1.56 1.4z"/>
-                            <text class="pin-text colombia" transform="translate(124.38 144.285)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text colombia" transform="translate(124.38 144.285)">
                                 Colombia
                             </text>
                         </g>
                         <g id="pin-group-argentina" class="pin-group pin-group-argentina">
                             <path id="AR" class="country" stroke="#FFF" stroke-width=".5" d="M166.23 344.63c-2.33.2-2.53.4-4-1.4-.83-.98-4.03.6-4.78-.22-.54-.5 0-4.2 0-5v-5.5c.86 1.7 1.52 5 2.97 6.1 2.5 2 4.07 2.8 7.1 3.7l-1.3 2.5zm1.5-122.44l1.65 2.1c.32-.7.65-2.5 1.5-2.4 1.46 0 2.3-.2 3.28.8 1.67 1.6 3.7 4.6 6 5.1 2.53.5 4.57 2.4 6.97 3.4 2.68 1.1-.72 4.9-1.6 6.4 1.88.5 6.48 2.4 8.26.7 1-1 2.3-1.8 2.6-3.2.2-1.3.9-3.5 2.2-1.8.5.7 1.7 2.9.7 3.6-1.4.9-2.7 1.9-4.1 2.8-2.5 1.7-4.5 4.6-6.4 6.8-1.4 1.6-2.1 5.4-2.1 7.5 0 .7.2 1.7 0 2.4s-.7.9-.8 1.8c-.2 1.8-.6 2.5.8 3.8 1.5 1.2 2.5 1.4 2.1 3.4-.3 1.7 1.6 1.7 1.5 3.5-.1 1.4-1.4 2.8-2.1 4-.9 1.5-1.9 1.7-3.5 2.4-3.1 1.4-6.7 1.4-10.1 1 .2.8.7 1.7.5 2.5-.3 1.2-.6 2-.2 3.2.5 1.9-2.7 2.9-4.3 2.7-.8-.1-1.9-1-2.6-1.3-1.2-.6-1.1 1.8-1.1 2.2.2 1.5-.1 2.2 1.2 2.9 1.3.8 1.4.3 2.5-.6.7 1.7 1.2 1.8-.4 2.6-1.4.6-2 1.3-3 2.3-.9.9-.8 2.1-.9 3.3-.1.7-.2 2.8-.8 3.3-.7.5-2.2-.5-2.9.2-.9.8-1.9 1.4-2.2 2.5-.5 1.6-.9 1.9.2 3.1.9.9 1.5 1.9 2.8 2.3 1.8.5 1.9.3 1.4 2.1-.4 1.4-.4 2-1.6 2.8-.9.6-2.2 1.1-2.5 2.2l-1.6 4.2c-.6 1.6-4.2 1.9-3.8 4.3l.9 4.3c.2.9 1.4 2 1.9 2.7-2.9-.5-5.5-1.1-8.5-1.4-2.1-.2-2-.1-2.9-2-.6-1.3-.3-2.7-.3-4.2-1.6.3-2.3.5-2.9-1.3-.2-.8-.6-3.8-.2-4.6.2-.5 1.3-1.1 1.8-1.5.5-.5.5-1 .8-1.7.4-1.5-.2-2.8.3-4.1 1.1-2.5 2.5-5.9 2.2-8.7-.1-.5-.5-1.7-.1-2 1-.6 1-.5.8-1.6-.1-.7-.6-.8-1.3-1.2-.4-.3.9-1.3.8-1.7 0-.5-1-1-1.3-1.5-.3-.6-.2-1.6-.3-2.2-.1-.4-.5-1.8-.4-2.2.4-.9 1.2-.3 1-1.4-.4-3.3-.2-5.8.5-9 .1-.5.14-1.7.6-2 .3-.2 1.6-1 1.5-1.3-.4-1.6-.8-3.1-.8-4.7 0-2.1.4-2.3 1.8-3.9.8-.9 0-2.7.5-3.9.7-1.6 2.4-4.7.7-6.2-.6-.5-1.8-5.3-1.48-6 1.3-2.6 1.7-3.4 1.45-6.3-.2-1.9 1.9-4.5 2.8-5.9.4-.6 2-1.4 2-2.1.1-.4-.8-.8-.8-1.2-.03-.4.6-.7.6-1.1l-.1-4c0-1.3.3-1.2 1.5-1.8 1.3-.6 1.5-.6 1.9-2 .1-.2.4-2.8.3-2.7.57-.6 1.5-2.4 2.3-2.6.8-.3 2.8.6 3.6.7z"/>
                             <path class="pin argentina" d="M166 264.57c-.12.86.5 1.66 1.35 1.77v3l.2.75.22-.8v-3c.8-.1 1.38-.8 1.38-1.6 0-.9-.7-1.6-1.6-1.6-.78 0-1.45.5-1.56 1.3z"/>
-                            <text class="pin-text argentina" transform="translate(153.33 260.472)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text argentina" transform="translate(154.33 260.472)">
                                 Argentina
                             </text>
                         </g>
                         <g id="pin-group-usa" class="pin-group pin-group-usa">
                             <path id="US" class="country" stroke="#FFF" stroke-width=".5" d="M159.8 9.95c-.58-.56-.93-1.3-1.73-1-1.4.5-1.33.57-2.32-.58-1.5 2.17-2.28 3.62-2.97 6.15-.32 1.18-1 1.92-2.03 2.45-.42.2-1.02.07-1.16.55-.3.73-.1.72-.9.72-2.6 0-5.2 0-7.7.03-1.2 0-5.8 2.5-5.1 3.73 1.5 2.77-2.2 3-4 2.75-1.3-.17-2.3-.18-3.5.2-.1.03 0 1.7-.6 2.2-1.9 1.73-3.7 2.26-5.8 3.54-2.3 1.4-4 1.3-6.4.3.8-1.3 3-4 2.9-5.5-.1-1.1-.4-2.1-.6-3.2-.4-1.5-2.2.5-2.5.8-.9.9-1.3-.4-.7-1.1 1-1 1.4-1.5 1.4-3 0-2.7-2.5-3.4-4.7-4.2-.4 1.5-1.1 2.3-1.5 3.8l-.3-1.3c-1.9 1.5-3.3 4.3-2.3 6.7.7 1.9.9 6.7-2.3 6.7-1.2 0-1.7-1.3-1.8-2.5-.1-1-.5-2.8-.3-3.7.7-2.8 1.3-5.2 2.6-7.8-1.1.1-1.9 1.7-2.5 2.5-.7-.7.9-2.2 1.4-3 1-1.5 1.1-1.3 2.9-1.8 1.5-.4 2-.8 3.5-.6 1.2.2 2.2 0 3.4-.2-1-1.2-1.3-1.6-2.8-1.9-.6-.1-.4-1-.8-1.1-.5-.2-1.8.2-2.3.3-.7.1-2.6 1.2-3.1.9-1.2-1-2-1.5-3.5-2l.9-2.2c-1.7.9-3.4 2-5.2 2.9-1.7.8-1.6.9-3-.2-.9-.7-2.3.2-3.3.5-.2-2.2 5.2-4.6 6.7-5.4-1.1-.4-2.7-1.3-3.9-1-2 .5-2.6.1-4.4-.8-1.2-.6-2.7-.7-4-.9-1.8-.2-1.8-1.3-2.2-3-.1-.5-1-.1-1 .4 0 .8.2 1-.6 1H5.5C6.1 3.3 7.73 7 6.2 9c-.4-1-.74-3.15-1.5-3.9-.4-.2-4-1.3-4.14-1-.45 1.1.6 2.6.88 3.8.4 1.6.67 3.04.8 4.7.3 3.2 0 6.17-.3 9.35-.14 1.4-.67 2.7-1.07 4-.3 1.1.8 2.5.9 3.6.04 1.7.04 3-.28 4.6-.4 1.9 1 2.07 1.3 3.76.2 2.1.5 2.8 1.7 4.5.4.5.7 1 1.2 1.4.9.8.3.8.7 1.6 1.5 3.1 2.8 5.5 5 8.2.7 1-.2 2.4 1.5 2.6.6.1 1.6 0 2.2.3 1 .5.9.9 2 1 1 .1.2.6.8 1 .4.3 1 .1 1.4.5.9 1 1.6 1.6 2 2.9.3 1.2 5.7.1 6.9 0l-.3.6c2.4.9 4.7 1.8 7.1 2.6 1 .3 2.5 1.2 3.5 1.2H44c1.53 0 2.5.6 2.5-1.1 0-.4 3.7-.2 4.3-.2.97 0 1.7 1.2 2.5 1.8 1.2.9 2.1 1.7 2.84 3.1.65 1.2.72 2.1 1.9 2.9.66.4 2.6 1.7 3.05 1 1-1.5 1.1-2.2 2.9-2.3 1.2 0 2.5.7 3.2 1.7.7 1.2 1.3 2.5 2.1 3.6 1 1.5 1.6 1.8 2.1 3.6.6 2.1 3.9 4 6.2 3.4-1.4-2-.9-5.3.8-6.9 1-1 2.3-1.3 3.5-2.1 1-.7 1.7-2.1 3-2.5.9-.3 2.8-1.1 3.8-.8.5.2 1.4.8 2 .7.6-.1 1.7-.5 2.3-.4.5.1 1.3 1.1 1.7 1.4.5.5 1.2.4 1.8.4.7.1.9-.5 1.6-.6.7-.1.8.9 1.5.1-1.1-.6-.3-1.9-1.1-2.8 1.1-.6 2.5-.8 3.8-.6 1.8.3 3.2.1 5-.1 1.2-.2 2.4 1.4 3.1 2.2.9 1.1 2.6-1.6 3.6-1.1 1.3.7 2.1 1.9 3 3.1 1.3 1.6.2 2.2.3 3.9.1 1.2 1.2 2.6 1.7 3.6l1.1 2c.4.7 1 .8 1.5 1.4.6.8 0 1.27 1.1 1.5.4.1 1.3.3 1.6-.3.6-1.6.7-2.9.8-4.6.1-2.6-1.8-5.6-2.6-8-1-2.9-2.1-5.5-.2-8.3.7-1.05 1.6-2 2.6-2.7l2.2-1.6c.5-.4.3-1.1.8-1.4.9-.8 1.2-1.2 2.5-1.37.8-.1 1.3-1.53 2-2 .7-.5 1.9-.7 2.8-1 .6-.2 1.4-1.9 1.8-2.46.5-.8-.3-4.67-1.2-4.9-.6-.2-.3-2.5-.3-3-.1-.8-1.3-1.2-2-1.6l1.9.6c-.4-1.66-.6-2.2-.1-3.8.2 1.4 0 2.6 1 3.6 1.3 1.2-.7 2.14.1 3.2.7-1.4 1.5-2.74 2.4-4.06.6-.94-1-3.1-1.3-4.1.6.8 1.8.9 1.7 2 1.4-1.92 2.1-3.04 2.6-5.4-.3 0-.6-.15-.9-.14.3-.4.6-.8.9-1l-.1.4c2.1 0 3.8-.5 5.7-1.1-1-1.4-3.6-.2-5 0 2.1-1 4.1-1.1 6.3-1.8.9-.3 6.9-.7 3.6-2.7l.3 1.3c-2.5.5-2.4-3.8-1.6-5.1.7-1 1.1-2 2.2-2.4 1.3-.5 2.6-1 3.9-1.6 1.1-.5 2.1-1.1 3.2-1.8s1.2-1.14.3-2.3c-.9-1.03-1.6-1.53-1.6-2.9V9.2z"/>
                             <path class="pin usa" d="M95.33 49.64c-.1.87.5 1.66 1.36 1.78v3l.2.75.2-.76v-2.9c.8-.1 1.4-.7 1.3-1.5 0-.9-.7-1.6-1.6-1.6-.8 0-1.5.6-1.6 1.4z"/>
-                            <text class="pin-text usa" transform="translate(91.29 45.992)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text usa" transform="translate(88.29 45.992)">
                                 U.S.A
-                            </text>
-                        </g>
-                        <g id="pin-group-cuba" class="pin-group pin-group-cuba">
-                            <path id="CU" class="country" stroke="#FFF" stroke-width=".5" d="M119.2 92.66c1.76.15 3.85-.07 5.47.57 1.06.4 1.74.64 2.53 1.42.68.68 1.7.23 2.6.1 1.18-.15 3.04 1.95 3.9 2.62 1.08.83 1.43.88 2.54 1.2.83.26 2.1.38 1.47 1.46 1.7.1 2.4.27 3.8 1.1 1.4.78-1.2 1.24-1.8 1.3-2.5.37-5.2.03-7.8.2l1.9-1.65c-1.3-.87-2.6-.68-3.7-1.7-.4-.4-.3-1.56-.8-1.83-.4-.23-1.2.22-1.7.08-1.1-.35-2.6-1.3-3.7-1.45-1.4-.17-3.1-.05-4.2-1 .4-.22.7-.57 1.1-.76l-2.6-.14c-.7-.04-1.5 1.27-2.1 1.55-.2.1-.7.03-1 .04-.4 0-.2.6-.5.74-.8.4-1.7.4-2.6.1 1.4-.8 2-2 3.4-2.7 1.4-.6 3-.5 4.3-1.2z"/>
-                            <path class="pin cuba" d="M131.7 93.98c-.1.87.5 1.66 1.37 1.77v3l.2.75.2-.75h.02v-3c.7-.1 1.3-.77 1.3-1.57 0-.87-.7-1.58-1.6-1.57-.8 0-1.5.6-1.6 1.4z"/>
-                            <text class="pin-text cuba" transform="translate(113.44 97.2)" font-family="'HelveticaNeue-Light'" font-size="8">
-                                Cuba
                             </text>
                         </g>
                         <g id="pin-group-jamaica" class="pin-group pin-group-jamaica">
                             <path id="JM" class="country" stroke="#FFF" stroke-width=".5" d="M132.4 106.67c1.28.18 3.36.26 3.83 1.78-1.58.04-2.93.75-4.4.06-2.02-.9-1.6-2.3.56-1.8z"/>
                             <path class="pin jamaica" d="M131.22 102.37c-.1.86.5 1.65 1.36 1.77v3l.2.75.22-.8v-3c.8-.1 1.38-.8 1.38-1.6 0-.9-.7-1.6-1.58-1.6-.8 0-1.47.6-1.58 1.3z"/>
-                            <text class="pin-text jamaica" transform="translate(107.63 109.44)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text jamaica" transform="translate(105.63 105.44)">
                                 Jamaica
                             </text>
                         </g>
                         <g id="pin-group-bahamas" class="pin-group pin-group-bahamas">
                             <path id="BS" class="country" stroke="#FFF" stroke-width=".5" d="M132.5 90.92c-1.15.5-.9-.93-1.4-1.6-1-1.37-1.07-.85-.5-2.7.36-1.13 1.35 1.15 1.38 1.24.43 1.12.5 1.84.5 3.06zm-.8-8.7c-1.45.24-2.95 1.17-3.24-.47-.02-.12 3.55-1.36 3.23.47zm2.3-.03l-.5 2.2c-.95-.6-.13-1.2-.46-2.1-.26-.7-1.18-.8-1.27-1.6l2.23 1.5z"/>
                             <path class="pin bahamas" d="M129.84 83.8c-.12.87.5 1.66 1.36 1.78v3l.2.75.2-.76h.02v-3c.78-.1 1.37-.77 1.37-1.56 0-.8-.8-1.5-1.6-1.5s-1.5.6-1.6 1.4z"/>
-                            <text class="pin-text bahamas" transform="translate(133.99 84.452)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text bahamas" transform="translate(133.99 84.452)">
                                 Bahamas
                             </text>
                         </g>
                         <g id="pin-group-mexico" class="pin-group pin-group-mexico">
                             <path id="MX" class="country" stroke="#FFF" stroke-width=".5" d="M77.52 84.44c-1.15 2.85-1.6 5.18-1.75 8.25-.06 1.2-.35 2 0 3.2.42 1.3 1.15 2.4 1.5 3.9.3 1.1 1.62 1.7 2.04 2.8.6 1.3 1 2.8 2.5 3.1l2.1.5c.6.1.8 1.1 1.3 1.2.7.1 3.5-1 4.5-1.1 2.6-.4 5.9-1.2 6.5-4 .2-.9-.1-3 .9-3.4 1.5-.7 2.8-1 4.4-1.4 1.1-.3 2.3.1 3.5-.1 1.5-.3 2.6.8 1.4 2.2-.5.6-2.4 2.6-1.6 3.5.5.5-.6 3.1-.9 3.8-1-2-2.2.1-2.8 1.1-.5-.4-.8-.4-.8.2h-4.4c-1.8 0 .3 2.1-2.1 1.7.9.7 1.9 1.3 2.4 2.2.8 1.2.2 1.1-1.4 1.1-1.9 0-1.8 0-2.7 1.6-.5 1 .1.6 0 1.3-.1.6-.4.9-.4 1.5-2.5-2.5-5.5-6-9.3-4.1-2.2 1.1-3 .6-5.3 0-2-.5-3.7-1.7-5.7-2.1-1.7-.3-3.4-1.3-4.9-2.2-.4-.2-1.7-1.5-2-1.5-.9-.1-1.7-.2-2.6-.5-1.9-.7-3-2-4.8-3-1.6-.9-2.4-2.3-3.1-3.9.3 0 .6-.3 1-.3-.6-.9.4-1.4.4-2.4 0-.8-.9-1.8-1.1-2.6-.3-1.5-2.4-3.9-3.5-4.8-.9-.8-1.9-1.5-2.7-2.3-.6-.7-.9-1.7-1.7-2.2-.8-.4-2.3-.8-2.5-1.8-.4-1.4 1.2-1.5-.5-2.4-.7-.4-1.7-1.1-2.1-1.8-.5-.8-.1-2.1-1.2-2.3-1.6-.3-3.8-2.5-4-4.1-.2-1.9-2.6-3.3-2.5-5.4.1-2.3-2.9-2.2-4.5-3.1-.6 2 0 4.9 1.2 6.5.3.5 3.6 4.4 3.7 4.4.2 0 1 2.2 1.5 2.7.8.7 1.3 1.7 2.2 2.5.8.7.9 2.1 1.2 3.1.3.9 1.1 1.9 1.6 2.8.2.4.2 1.1.2 1.6.1.4 1 .1 1.4.3.4.1 2.2 2.3 2.2 2.7 0 .6-1.5 2.2-1.8 1.5-.6-1.5-1-2.1-2.2-3.1-.7-.7-1.6-1.5-2.5-1.9-1.5-.9-1.2-1.1-1.2-2.9.1-1.4-.6-2-1.6-2.7-.6-.5-1.8-2-2.4-1.1-.6-1.1-1.6-1-2.4-1.6-.3-.2-2.2-2.2-1.3-2.1.9.1 1.9-.1 2-1.3.2-1.7-.6-2-1.8-3.2-.6-.7-1.7-.8-2.1-1.6l-1.6-3.3c-1-2-1.9-4-2.7-6l6.8-.6-.3.6 7 2.8c1 .3 2.5 1.2 3.5 1.2l5.2-.08c1.6 0 2.5.5 2.5-1.2 0-.4 3.7-.2 4.3-.2 1 0 1.7 1.25 2.6 1.8 1.2.9 2.1 1.8 2.88 3.1.67 1.2.7 2.1 1.9 2.85.67.4 2.6 1.7 3.06 1 1-1.5 1.1-2.2 2.9-2.2 1.2 0 2.5.66 3.1 1.7.7 1.1 1.3 2.5 2.1 3.6 1 1.4 1.6 1.8 2.1 3.56.6 2.2 3.9 4 6.2 3.4z"/>
                             <path class="pin mexico" d="M65.57 95.58c-.1.86.5 1.65 1.36 1.77v3l.2.75.2-.76h.02v-3c.8-.1 1.38-.77 1.37-1.56 0-.88-.7-1.58-1.58-1.58-.8 0-1.47.6-1.57 1.38z"/>
-                            <text class="pin-text mexico" transform="translate(58.334 92.655)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text mexico" transform="translate(53.334 92.655)">
                                 Mexico
                             </text>
                         </g>
                         <g id="pin-group-puerto-rico" class="pin-group pin-group-puerto-rico">
                             <path id="PR" class="country" stroke="#FFF" stroke-width=".5" d="M164.04 106.6c.32.06 2.44.33 1.75 1.04-.9.83-1.7.47-2.9.53-.7.04-2.4.23-1.7-1.16.4-.8 1.9-.4 2.7-.4z"/>
                             <path class="pin puerto-rico" d="M162.1 101.88c-.12.86.5 1.66 1.36 1.77v3l.2.75.2-.76h.02v-3c.78-.1 1.37-.77 1.37-1.56 0-.87-.7-1.58-1.58-1.57-.8 0-1.47.6-1.57 1.4z"/>
-                            <text class="pin-text puerto-rico" transform="translate(165.98 105.953)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text puerto-rico" transform="translate(165.98 105.953)">
                                 Puerto Rico
                             </text>
                         </g>
                         <g id="pin-group-dominican" class="pin-group pin-group-dominican active-pin">
                             <path id="DO" class="country" stroke="#FFF" stroke-width=".5" d="M148.8 103.06c.7-1.3 3.03-.27 4.04.2.9.4.8-.22 1.34.88.18.37 1.22.12 1.6.1-.1.27.03.62-.08.88 1.2-.04 1.72.48 2.63 1.2-.94 1.08-.84 1.3-2.17.65-.44-.2-2.37-.16-2.66.15-1.02 1.08-1.52-.38-2-.16-1 .47-1.27 1.37-1.8 2.32-1.35-.44-.5-2.1-1.54-2.98 1.3-.52.8-2.2.65-3.24z"/>
                             <path class="pin dominican" d="M150.1 98.43c-.12.86.5 1.66 1.35 1.77v3l.2.75.22-.75v-3c.8-.1 1.38-.77 1.38-1.57 0-.87-.72-1.58-1.6-1.57-.78 0-1.46.58-1.56 1.37z"/>
-                            <text class="pin-text dominican" transform="translate(149.347 96.057)" font-family="'HelveticaNeue-Light'" font-size="8">
+                            <text class="pin-text dominican" transform="translate(149.347 96.057)">
                                 Dominican Republic
                             </text>
                         </g>
@@ -499,17 +487,18 @@
             <div id="locations-regions" class="locations-regions">
                 <div id="pin-group-usa-tab" class="locations-tab">
                     <h3 class="locations-tab-title">U.S.A</h3>
-                    <h4>Miami</h4>
+                    <h4 class="locations-tab-title">Miami</h4>
                     <ul>
                         <li><a href="https://memiami.talentnest.com" target="_blank" rel="noopener noreferrer">ME Miami</a></li>
+                        <li><a href="https://corporateregionalamerica.talentnest.com" target="_blank" rel="noopener noreferrer">The Sol Group Corporation</a></li>
                     </ul>
-                    <h4>Orlando</h4>
+                    <h4 class="locations-tab-title">Orlando</h4>
                     <ul>
                         <li><a href="https://meliaorlando.talentnest.com" target="_blank" rel="noopener noreferrer">Meliá Orlando Suite Hotel</a></li>
                     </ul>
-                    <h4>New York</h4>
+                    <h4 class="locations-tab-title">New York</h4>
                     <ul>
-                        <li><a href="https://innsideny.talentnest.com" target="_blank" rel="noopener noreferrer">Innside New York</a></li>
+                        <li><a href="https://innsideny.talentnest.com" target="_blank" rel="noopener noreferrer">Innside New York Nomad</a></li>
                     </ul>
                 </div>
                 <div id="pin-group-dominican-tab" class="locations-tab visible-pin-tab" style="display: block;">
@@ -527,9 +516,6 @@
                 </div>
                 <div id="pin-group-jamaica-tab" class="locations-tab">
                     <h3 class="locations-tab-title">Jamaica</h3>
-                    <ul>
-                        <li><a href="https://meliabracovillage.talentnest.com" target="_blank" rel="noopener noreferrer">Meliá Braco Village</a></li>
-                    </ul>
                 </div>
                 <div id="pin-group-puerto-rico-tab" class="locations-tab">
                     <h3 class="locations-tab-title">Puerto Rico</h3>
@@ -539,9 +525,8 @@
                 </div>
                 <div id="pin-group-mexico-tab" class="locations-tab">
                     <h3 class="locations-tab-title">Mexico</h3>
-                    <h4>Cancun</h4>
+                    <h4 class="locations-tab-title">Cancun</h4>
                     <ul>
-                        <li><a href="https://meliahotels.talentnest.com" target="_blank" rel="noopener noreferrer">ME Cancun</a></li>
                         <li><a href="https://clubmeliacancun.talentnest.com" target="_blank" rel="noopener noreferrer">Club Meliá Cancun</a></li>
                         <li><a href="https://meliahotels.talentnest.com" target="_blank" rel="noopener noreferrer">Paradisus Cancun</a></li>
                     </ul>
@@ -562,7 +547,10 @@
                     <ul>
                         <li>
                             Meliá Cozumel
-                            (<a href="mailto:formacion.cozumel@melia.com">formacion.cozumel@melia.com</a>)
+                            <br/>
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:formacion.cozumel@melia.com" title="formacion.cozumel@melia.com">(contact the hotel)</a>
+                            </div>
                         </li>
                     </ul>
                 </div>
@@ -583,17 +571,22 @@
                     <ul>
                         <li>
                             Meliá Lima
-                            (<a href="mailto:Seleccion.melia.lima@melia.com">Seleccion.melia.lima@melia.com</a>)
+                            <br/>
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:Seleccion.melia.lima@melia.com" title="Seleccion.melia.lima@melia.com">(contact the hotel)</a>
+                            </div>
                         </li>
                     </ul>
-                </div>
-                <div id="pin-group-cuba-tab" class="locations-tab">
-                    <h3 class="locations-tab-title">Cuba</h3>
                 </div>
                 <div id="pin-group-venezuela-tab" class="locations-tab">
                     <h3 class="locations-tab-title">Venezuela</h3>
                     <ul>
-                        <li>Gran Meliá Caracas</li>
+                        <li>
+                            Gran Meliá Caracas
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:captacionrhccs@melia.com" title="captacionrhccs@melia.com">(contact the hotel)</a>
+                            </div>
+                        </li>
                     </ul>
                 </div>
                 <div id="pin-group-argentina-tab" class="locations-tab">
@@ -601,11 +594,21 @@
                     <ul>
                         <li>
                             Meliá Buenos Aires
-                            (<a href="mailto:Hotel@meliarecoletaplaza.com.ar">Hotel@meliarecoletaplaza.com.ar</a>)
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:cv@meliabuenosaires.com.ar" title="cv@meliabuenosaires.com.ar">(contact the hotel)</a>
+                            </div>
+                        </li>
+                        <li>
+                            Meliá Iguazú
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:rrhh.melia.iguazu@melia.com" title="rrhh.melia.iguazu@melia.com">(contact the hotel)</a>
+                            </div>
                         </li>
                         <li>
                             Meliá Recoleta Plaza
-                            (<a href="mailto:cv@meliabuenosaires.com.ar">cv@meliabuenosaires.com.ar</a>)
+                            <div class="locations-tab-contact-link">
+                                <a href="mailto:Hotel@meliarecoletaplaza.com.ar" title="Hotel@meliarecoletaplaza.com.ar">(contact the hotel)</a>
+                            </div>
                         </li>
                     </ul>
                 </div>
@@ -623,8 +626,12 @@
             confidentiality nor the proper receipt of the message sent, so that the Company shall not be liable for any
             damages caused.
             <div class="social-media">
-                <a href="https://twitter.com/MHICareers" rel="noopener noreferrer" target="_blank" title="Síguenos en Twitter"><img alt="Twitter" class="social-media-image" height="32" src="https://d4fpme2i4v12t.cloudfront.net/assets/common_assets/melia/images/twitter-5bee2c6bd1d3fa1bea5309f794bcb316.png" width="32"></a>
-                <a href="https://www.linkedin.com/company/melia-hotels-international" rel="noopener noreferrer" target="_blank" title="Síguenos en LinkedIn"><img alt="Linkedin" class="social-media-image" height="32" src="https://d4fpme2i4v12t.cloudfront.net/assets/common_assets/melia/images/linkedin-90ac9b1d28523471b3b181f081d13711.png" width="32"></a>
+                <a href="https://twitter.com/MHICareers" rel="noopener noreferrer" target="_blank" title="Follow us on Twitter">
+                    <img alt="Twitter" class="social-media-image" height="32" src="https://d4fpme2i4v12t.cloudfront.net/assets/common_assets/melia/images/twitter-5bee2c6bd1d3fa1bea5309f794bcb316.png" width="32">
+                </a>
+                <a href="https://www.linkedin.com/company/melia-hotels-international" rel="noopener noreferrer" target="_blank" title="Follow us on LinkedIn">
+                    <img alt="Linkedin" class="social-media-image" height="32" src="https://d4fpme2i4v12t.cloudfront.net/assets/common_assets/melia/images/linkedin-90ac9b1d28523471b3b181f081d13711.png" width="32">
+                </a>
             </div>
         </div>
     </section>


### PR DESCRIPTION
- Correct "Our brands" text
- Add a link at the end of Our Brands paragraph
- Correct title text of social media

Map:
   - Match font on the map to the font of the properties list next to map
   - For the brands that do not have a TN career page, add a link
“contact the hotel” linking to hotel's email address

Cuba:
- Remove location from the map

Mexico:
- Remove ME Cancun

Jamaica:
- Remove Meliá Braco Village (leave Jamaica blank for now)

Argentina:
- Add Meliá Iguazú (rrhh.melia.iguazu@melia.com)
- Correct email for Meliá Buenos Aires (cv@meliabuenosaires.com.ar)
- Correct email for Meliá Recoleta Plaza (Hotel@meliarecoletaplaza.com.ar)

Venezuela:
- Add email address to Gran Meliá Caracas (captacionrhccs@melia.com)

USA:
- Add “The Sol Group Corporation” under Miami (https://corporateregionalamerica.talentnest.com/en/jobs)
- Innside New York Nomad - add “Nomad” at the end